### PR TITLE
fix(release): Skip running lint during prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "lint": "biome check",
         "convert-spec": "ts-node -T scripts/convert-spec.ts",
         "semantic-release": "semantic-release",
-        "prepublishOnly": "yarn run build"
+        "prepublishOnly": "yarn run build-ts"
     },
     "devDependencies": {
         "@biomejs/biome": "1.8.3",


### PR DESCRIPTION
A new version of the `package.json` will be generated with bumped
version causing a reformat of the file. We can skip running lint during
the publish phase

Blame: https://github.com/Dintero/Dintero.Node.SDK/pull/161
Rel: https://github.com/Dintero/epics/issues/489
