### PR TITLE
fix(release): Add `publishConfig` with public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "files": ["dist"],
     "license": "MIT",
     "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
     "author": "Dintero <support@dintero.com> (https://dintero.com/)",
     "jest": {
         "preset": "ts-jest",


### PR DESCRIPTION
Release was failing with error

> 'npm error 402 Payment Required - \
> PUT https://registry.npmjs.org/@dintero%2fnode-sdk \
> - You must sign up for private packages\n' +
