### PR TITLE
feat(tokenCache): Add `tokenCache` option to the client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import createOpenApiFetchClient from "openapi-fetch";
 import {
     createAuthMiddleware,
     createVersionPrefixMiddleware,
+    defaultTokenCache,
     extractAccountId,
 } from "./middleware";
 import type { CheckoutPaths, ClientOptions, CorePaths } from "./types";
@@ -10,6 +11,7 @@ export const createClient = (options: ClientOptions) => {
     const config: Required<ClientOptions> = {
         checkout: { baseUrl: "https://checkout.dintero.com" },
         core: { baseUrl: "https://api.dintero.com" },
+        tokenCache: options.tokenCache ?? defaultTokenCache(),
         ...options,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,10 +28,20 @@ export type CorePaths = Pick<
     | "/v2/accounts/{aid}/payout/payout-destinations/{payout_destination_id}/transfers"
 >;
 
+export type TokenCache = {
+    get: (aud: string) => Promise<{ accessToken: string } | undefined>;
+    set: (
+        aud: string,
+        accessToken: string,
+        expiresIn: number,
+    ) => Promise<{ accessToken: string }>;
+};
+
 export type ClientOptions = {
     clientId: string;
     clientSecret: string;
     audience: string;
+    tokenCache?: TokenCache;
     core?: { baseUrl: string };
     checkout?: { baseUrl: string };
 };


### PR DESCRIPTION
The new `tokenCache` provides a mechanism for providing your own cache
of the access tokens
