### PR TITLE
fix(pack): resolveJsonModule + import from ../package.json

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,9 @@
 import type { Client, Middleware } from "openapi-fetch";
-import { version } from "../package.json";
+
 import type { CorePaths } from "./types";
 import type { ClientOptions } from "./types";
+
+const pkg = require("../package.json");
 
 export const extractAccountId = (audience: string): string => {
     if (!audience || !audience.includes("://")) {
@@ -81,7 +83,7 @@ export const createDefaultHeadersMiddleware = (): Middleware => ({
         if (!request.headers.get("User-Agent")) {
             request.headers.set(
                 "User-Agent",
-                `Dintero.Node.SDK/${version} (+https://github.com/Dintero/Dintero.Node.SDK)`,
+                `Dintero.Node.SDK/${pkg.version} (+https://github.com/Dintero/Dintero.Node.SDK)`,
             );
         }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "strict": true,
         "baseUrl": "./",
         "types": ["jest", "node"],
-        "resolveJsonModule": true,
         "noUnusedLocals": true,
         "skipLibCheck": true,
         "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Import of a json file located outside the src folder result in a
different dist tructure that does match the main/types defined in
package.json

```
dist/
├── package.json
└── src
    ├── client.d.ts
    ├── client.js
    ├── dintero.d.ts
    ├── dintero.js
    ├── middleware.d.ts
    ├── middleware.js
    ├── types.d.ts
    └── types.js
```

> We expect no package.json or src folder in the dist

Rel: https://github.com/Dintero/shopify-service/pull/115
